### PR TITLE
Early access versions: Fix typo

### DIFF
--- a/en/Obsidian/Early access versions.md
+++ b/en/Obsidian/Early access versions.md
@@ -58,7 +58,7 @@ To switch back to using public versions (not early access) on desktop:
    - Linux: `~/.config/obsidian/obsidian-VERSION.asar`
 4. Restart Obsidian.
 
-## Switch back to public versions on desktop
+## Switch back to public versions on mobile
 
 To switch back to using public versions (not early access) on mobile:
 


### PR DESCRIPTION
The heading for reverting on mobile said "desktop" instead of "mobile". 

Reported by Warrobot10 on the forum. https://forum.obsidian.md/t/typo-in-obsidian-help-site/76339?u=cawlinteffid